### PR TITLE
feat: add dark and light theme toggle

### DIFF
--- a/404.html
+++ b/404.html
@@ -80,5 +80,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/about-me.html
+++ b/about-me.html
@@ -169,5 +169,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/components/feature-card2.html
+++ b/components/feature-card2.html
@@ -85,5 +85,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="../public/theme-toggle.js"></script>
+</body>
 </html>

--- a/components/gallery-card.html
+++ b/components/gallery-card.html
@@ -78,5 +78,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="../public/theme-toggle.js"></script>
+</body>
 </html>

--- a/components/gallery-card1.html
+++ b/components/gallery-card1.html
@@ -79,5 +79,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="../public/theme-toggle.js"></script>
+</body>
 </html>

--- a/components/gallery-card2.html
+++ b/components/gallery-card2.html
@@ -82,5 +82,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="../public/theme-toggle.js"></script>
+</body>
 </html>

--- a/components/gallery-card3.html
+++ b/components/gallery-card3.html
@@ -79,5 +79,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="../public/theme-toggle.js"></script>
+</body>
 </html>

--- a/components/gallery-card4.html
+++ b/components/gallery-card4.html
@@ -79,5 +79,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="../public/theme-toggle.js"></script>
+</body>
 </html>

--- a/daq.html
+++ b/daq.html
@@ -331,5 +331,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/dissertation.html
+++ b/dissertation.html
@@ -405,5 +405,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -455,5 +455,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/isaac.html
+++ b/isaac.html
@@ -316,5 +316,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/my-work.html
+++ b/my-work.html
@@ -283,5 +283,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/plant-watering.html
+++ b/plant-watering.html
@@ -312,5 +312,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/public/theme-toggle.js
+++ b/public/theme-toggle.js
@@ -1,0 +1,27 @@
+(function() {
+  const applyTheme = (theme) => {
+    document.body.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  };
+
+  const currentTheme = localStorage.getItem('theme') || 'dark';
+  applyTheme(currentTheme);
+
+  const button = document.createElement('button');
+  button.id = 'theme-toggle';
+  button.textContent = 'Toggle Theme';
+  Object.assign(button.style, {
+    position: 'fixed',
+    top: '1rem',
+    right: '1rem',
+    padding: '0.5rem 1rem',
+    cursor: 'pointer',
+    zIndex: '1000'
+  });
+  document.body.appendChild(button);
+
+  button.addEventListener('click', () => {
+    const newTheme = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+    applyTheme(newTheme);
+  });
+})();

--- a/ropeless-fishing-gear-demonstrator.html
+++ b/ropeless-fishing-gear-demonstrator.html
@@ -416,5 +416,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/rov.html
+++ b/rov.html
@@ -383,5 +383,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,13 +1,13 @@
 :root {
-  --dl-color-gray-500: #595959;
-  --dl-color-gray-700: #999999;
-  --dl-color-gray-800: #cbcbcbff;
-  --dl-color-gray-900: #D9D9D9;
+  --dl-color-gray-500: #a6a6a6;
+  --dl-color-gray-700: #cccccc;
+  --dl-color-gray-800: #e0e0e0;
+  --dl-color-gray-900: #f2f2f2;
   --dl-color-danger-300: #A22020;
   --dl-color-danger-500: #BF2626;
   --dl-color-danger-700: #E14747;
-  --dl-color-gray-black: #000000;
-  --dl-color-gray-white: #FFFFFF;
+  --dl-color-gray-black: #FFFFFF;
+  --dl-color-gray-white: #000000;
   --dl-space-space-unit: 8px;
   --dl-color-primary-100: #003EB3;
   --dl-color-primary-300: #0074F0;
@@ -28,6 +28,15 @@
   --dl-radius-radius-radius24: 24px;
   --dl-space-space-doubleunit: 16px;
   --dl-space-space-tripleunit: 24px;
+}
+
+body[data-theme='light'] {
+  --dl-color-gray-500: #595959;
+  --dl-color-gray-700: #999999;
+  --dl-color-gray-800: #cbcbcbff;
+  --dl-color-gray-900: #D9D9D9;
+  --dl-color-gray-black: #000000;
+  --dl-color-gray-white: #FFFFFF;
 }
 .teleport-show {
   display: flex !important;

--- a/the-unit.html
+++ b/the-unit.html
@@ -315,5 +315,6 @@
       </div>
     </div>
     <script src="https://unpkg.com/@teleporthq/teleport-custom-scripts"></script>
-  </body>
+    <script src="public/theme-toggle.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- support theme switching between dark and light modes
- default to dark mode and remember preference across visits

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4836887ec8329b5f864ac32425684